### PR TITLE
SGGame: Add evolution moves

### DIFF
--- a/config/SGGame/pokemon.json
+++ b/config/SGGame/pokemon.json
@@ -15991,7 +15991,7 @@
 			"item": "thunderstone",
 			"evoMove": "psychic",
 			"evolvesTo": null
-		},
+		}
 	},
 	"sandshrewalola": {
 		"id": "sandshrewalola",
@@ -16132,7 +16132,7 @@
 			"item": "leafstone",
 			"evoMove": "dragonhammer",
 			"evolvesTo": null
-		},
+		}
 	},
 	"marowakalola": {
 		"id": "marowakalola",

--- a/config/SGGame/pokemon.json
+++ b/config/SGGame/pokemon.json
@@ -64,6 +64,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 32,
+			"evoMove": "petaldance",
 			"evolvesTo": null
 		},
 		"baseExp": 236,
@@ -123,6 +124,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "wingattack",
 			"evolvesTo": null
 		},
 		"baseExp": 240,
@@ -221,6 +223,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 7,
+			"evoMove": "harden",
 			"evolvesTo": "butterfree"
 		},
 		"baseExp": 72,
@@ -241,6 +244,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 10,
+			"evoMove": "gust",
 			"evolvesTo": null
 		},
 		"baseExp": 178,
@@ -280,6 +284,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 7,
+			"evoMove": "harden",
 			"evolvesTo": "beedrill"
 		},
 		"baseExp": 72,
@@ -398,6 +403,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 20,
+			"evoMove": "scaryface",
 			"evolvesTo": null
 		},
 		"baseExp": 145,
@@ -476,6 +482,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 22,
+			"evoMove": "crunch",
 			"evolvesTo": null
 		},
 		"baseExp": 157,
@@ -968,6 +975,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 31,
+			"evoMove": "gust",
 			"evolvesTo": null
 		},
 		"baseExp": 158,
@@ -1007,6 +1015,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 26,
+			"evoMove": "sandtomb",
 			"evolvesTo": null
 		},
 		"baseExp": 149,
@@ -1046,6 +1055,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 28,
+			"evoMove": "swift",
 			"evolvesTo": null
 		},
 		"baseExp": 154,
@@ -1124,6 +1134,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 28,
+			"evoMove": "rage",
 			"evolvesTo": null
 		},
 		"baseExp": 159,
@@ -1222,6 +1233,7 @@
 		"evolution": {
 			"trigger": "item",
 			"item": "waterstone",
+			"evoMove": "submission",
 			"evolvesTo": null
 		},
 		"baseExp": 230,
@@ -1261,6 +1273,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 16,
+			"evoMove": "kinesis",
 			"evolvesTo": "alakazam"
 		},
 		"baseExp": 140,
@@ -1280,6 +1293,7 @@
 		"rate": "50",
 		"evolution": {
 			"trigger": "trade",
+			"evoMove": "kinesis",
 			"evolvesTo": null
 		},
 		"baseExp": 225,
@@ -1338,6 +1352,7 @@
 		"rate": "45",
 		"evolution": {
 			"trigger": "trade",
+			"evoMove": "strength",
 			"evolvesTo": null
 		},
 		"baseExp": 227,
@@ -1397,6 +1412,7 @@
 		"evolution": {
 			"trigger": "item",
 			"item": "leafstone",
+			"evoMove": "leaftornado",
 			"evolvesTo": null
 		},
 		"baseExp": 221,
@@ -1533,6 +1549,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 40,
+			"evoMove": "furyattack",
 			"evolvesTo": null
 		},
 		"baseExp": 175,
@@ -1572,6 +1589,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 37,
+			"evoMove": "withdraw",
 			"evolvesTo": null
 		},
 		"baseExp": 172,
@@ -1611,6 +1629,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "triattack",
 			"evolvesTo": "magnezone"
 		},
 		"baseExp": 163,
@@ -1669,6 +1688,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 31,
+			"evoMove": "triattack",
 			"evolvesTo": null
 		},
 		"baseExp": 165,
@@ -1708,6 +1728,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 34,
+			"evoMove": "sheercold",
 			"evolvesTo": null
 		},
 		"baseExp": 166,
@@ -1747,6 +1768,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 38,
+			"evoMove": "venomdrench",
 			"evolvesTo": null
 		},
 		"baseExp": 175,
@@ -1825,6 +1847,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 25,
+			"evoMove": "shadowpunch",
 			"evolvesTo": "gengar"
 		},
 		"baseExp": 142,
@@ -1844,6 +1867,7 @@
 		"rate": "45",
 		"evolution": {
 			"trigger": "trade",
+			"evoMove": "shadowpunch",
 			"evolvesTo": null
 		},
 		"baseExp": 225,
@@ -2019,6 +2043,7 @@
 		"evolution": {
 			"trigger": "item",
 			"item": "leafstone",
+			"evoMove": "stomp",
 			"evolvesTo": null
 		},
 		"baseExp": 186,
@@ -2079,6 +2104,7 @@
 			"trigger": "level",
 			"level": 20,
 			"stat": "atk>def",
+			"evoMove": "doublekick",
 			"evolvesTo": null
 		},
 		"baseExp": 159,
@@ -2100,6 +2126,7 @@
 			"trigger": "level",
 			"level": 20,
 			"stat": "def>atk",
+			"evoMove": "cometpunch",
 			"evolvesTo": null
 		},
 		"baseExp": 159,
@@ -2158,6 +2185,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 35,
+			"evoMove": "doublehit",
 			"evolvesTo": null
 		},
 		"baseExp": 172,
@@ -2197,6 +2225,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 42,
+			"evoMove": "hammerarm",
 			"evolvesTo": "rhyperior"
 		},
 		"baseExp": 170,
@@ -2549,6 +2578,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 20,
+			"evoMove": "bite",
 			"evolvesTo": null
 		},
 		"baseExp": 189,
@@ -2626,6 +2656,7 @@
 		"evolution": {
 			"trigger": "item",
 			"item": "waterstone",
+			"evoMove": "watergun",
 			"evolvesTo": null
 		},
 		"baseExp": 184,
@@ -2646,6 +2677,7 @@
 		"evolution": {
 			"trigger": "item",
 			"item": "thunderstone",
+			"evoMove": "thundershock",
 			"evolvesTo": null
 		},
 		"baseExp": 184,
@@ -2666,6 +2698,7 @@
 		"evolution": {
 			"trigger": "item",
 			"item": "firestone",
+			"evoMove": "ember",
 			"evolvesTo": null
 		},
 		"baseExp": 184,
@@ -2724,6 +2757,7 @@
 		"evolution": {
 			"trigger": "level",
 			"item": 40,
+			"evoMove": "spikecannon",
 			"evolvesTo": null
 		},
 		"baseExp": 173,
@@ -2763,6 +2797,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 40,
+			"evoMove": "slash",
 			"evolvesTo": null
 		},
 		"baseExp": 173,
@@ -2918,6 +2953,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 55,
+			"evoMove": "wingattack",
 			"evolvesTo": null
 		},
 		"baseExp": 270,
@@ -3015,6 +3051,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 32,
+			"evoMove": "petaldance",
 			"evolvesTo": null
 		},
 		"baseExp": 236,
@@ -3172,6 +3209,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 15,
+			"evoMove": "agility",
 			"evolvesTo": null
 		},
 		"baseExp": 145,
@@ -3289,6 +3327,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 22,
+			"evoMove": "swordsdance",
 			"evolvesTo": null
 		},
 		"baseExp": 140,
@@ -3309,6 +3348,7 @@
 		"evolution": {
 			"trigger": "level",
 			"happiness": 255,
+			"evoMove": "crosspoison",
 			"evolvesTo": null
 		},
 		"baseExp": 241,
@@ -3348,6 +3388,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 27,
+			"evoMove": "stockpile|swallow|spitup",
 			"evolvesTo": null
 		},
 		"baseExp": 161,
@@ -3483,6 +3524,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 25,
+			"evoMove": "airslash",
 			"evolvesTo": null
 		},
 		"baseExp": 165,
@@ -3542,6 +3584,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "thunderpunch",
 			"evolvesTo": null
 		},
 		"baseExp": 230,
@@ -3562,6 +3605,7 @@
 		"evolution": {
 			"trigger": "item",
 			"item": "sunstone",
+			"evoMove": "magicalleaf",
 			"evolvesTo": null
 		},
 		"baseExp": 221,
@@ -3622,6 +3666,7 @@
 		"evolution": {
 			"trigger": "level",
 			"move": "mimic",
+			"evoMove": "slam",
 			"evolvesTo": null
 		},
 		"baseExp": 144,
@@ -3838,6 +3883,7 @@
 			"trigger": "level",
 			"happiness": 255,
 			"time": "day",
+			"evoMove": "confusion",
 			"evolvesTo": null
 		},
 		"baseExp": 184,
@@ -3859,6 +3905,7 @@
 			"trigger": "level",
 			"happiness": 255,
 			"time": "night",
+			"evoMove": "pursuit",
 			"evolvesTo": null
 		},
 		"baseExp": 184,
@@ -4014,6 +4061,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 31,
+			"evoMove": "mirrorshot|autotomize",
 			"evolvesTo": null
 		},
 		"baseExp": 163,
@@ -4285,6 +4333,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 38,
+			"evoMove": "shellsmash",
 			"evolvesTo": null
 		},
 		"baseExp": 151,
@@ -4324,6 +4373,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 33,
+			"evoMove": "furryattack",
 			"evolvesTo": "mamoswine"
 		},
 		"baseExp": 158,
@@ -4384,6 +4434,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 25,
+			"evoMove": "octazooka",
 			"evolvesTo": null
 		},
 		"baseExp": 168,
@@ -4540,6 +4591,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 25,
+			"evoMove": "furyattack",
 			"evolvesTo": null
 		},
 		"baseExp": 175,
@@ -4638,6 +4690,7 @@
 			"trigger": "level",
 			"level": 20,
 			"stats": "atk=def",
+			"evoMove": "rollingkick",
 			"evolvesTo": null
 		},
 		"baseExp": 159,
@@ -4946,6 +4999,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 16,
+			"evoMove": "furycutter",
 			"evolvesTo": "sceptile"
 		},
 		"baseExp": 142,
@@ -4966,6 +5020,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "dualchop",
 			"evolvesTo": null
 		},
 		"baseExp": 239,
@@ -5005,6 +5060,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 16,
+			"evoMove": "doublekick",
 			"evolvesTo": "blaziken"
 		},
 		"baseExp": 142,
@@ -5025,6 +5081,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "blazekick",
 			"evolvesTo": null
 		},
 		"baseExp": 239,
@@ -5064,6 +5121,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 16,
+			"evoMove": "mudshot",
 			"evolvesTo": "swampert"
 		},
 		"baseExp": 142,
@@ -5123,6 +5181,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 18,
+			"evoMove": "snarl",
 			"evolvesTo": null
 		},
 		"baseExp": 147,
@@ -5201,6 +5260,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 7,
+			"evoMove": "harden",
 			"evolvesTo": "beautifly"
 		},
 		"baseExp": 72,
@@ -5221,6 +5281,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 10,
+			"evoMove": "gust",
 			"evolvesTo": null
 		},
 		"baseExp": 178,
@@ -5241,6 +5302,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 7,
+			"evoMove": "harden",
 			"evolvesTo": "dustox"
 		},
 		"baseExp": 72,
@@ -5261,6 +5323,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 10,
+			"evoMove": "gust",
 			"evolvesTo": null
 		},
 		"baseExp": 173,
@@ -5457,6 +5520,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 25,
+			"evoMove": "protect",
 			"evolvesTo": null
 		},
 		"baseExp": 154,
@@ -5594,6 +5658,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 23,
+			"evoMove": "machpunch",
 			"evolvesTo": null
 		},
 		"baseExp": 161,
@@ -5653,6 +5718,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "swagger",
 			"evolvesTo": null
 		},
 		"baseExp": 252,
@@ -5692,6 +5758,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 20,
+			"evoMove": "doubleteam|screech|furycutter",
 			"evolvesTo": null
 		},
 		"baseExp": 160,
@@ -5752,6 +5819,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 20,
+			"evoMove": "bite",
 			"evolvesTo": "exploud"
 		},
 		"baseExp": 126,
@@ -5772,6 +5840,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 40,
+			"evoMove": "crunch",
 			"evolvesTo": null
 		},
 		"baseExp": 221,
@@ -6199,6 +6268,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 26,
+			"evoMove": "bodyslam",
 			"evolvesTo": null
 		},
 		"baseExp": 163,
@@ -6238,6 +6308,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "slash",
 			"evolvesTo": null
 		},
 		"baseExp": 161,
@@ -6316,6 +6387,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 33,
+			"evoMove": "rockslide",
 			"evolvesTo": null
 		},
 		"baseExp": 161,
@@ -6374,6 +6446,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 32,
+			"evoMove": "teeterdance",
 			"evolvesTo": null
 		},
 		"baseExp": 165,
@@ -6432,6 +6505,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 35,
+			"evoMove": "dragonbreath",
 			"evolvesTo": "flygon"
 		},
 		"baseExp": 119,
@@ -6452,6 +6526,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 45,
+			"evoMove": "dragonclaw",
 			"evolvesTo": null
 		},
 		"baseExp": 234,
@@ -6491,6 +6566,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 32,
+			"evoMove": "spikyshield",
 			"evolvesTo": null
 		},
 		"baseExp": 166,
@@ -6530,6 +6606,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 35,
+			"evoMove": "dragonbreath",
 			"evolvesTo": null
 		},
 		"baseExp": 172,
@@ -6645,6 +6722,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "thrash",
 			"evolvesTo": null
 		},
 		"baseExp": 164,
@@ -6684,6 +6762,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "swift",
 			"evolvesTo": null
 		},
 		"baseExp": 164,
@@ -6723,6 +6802,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "hyperbeam",
 			"evolvesTo": null
 		},
 		"baseExp": 175,
@@ -6840,6 +6920,7 @@
 		"evolution": {
 			"trigger": "trade",
 			"hold": "prismscale",
+			"evoMove": "waterpulse",
 			"evolvesTo": null
 		},
 		"baseExp": 189,
@@ -6956,6 +7037,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 37,
+			"evoMove": "shadowpunch",
 			"evolvesTo": "dusknoir"
 		},
 		"baseExp": 159,
@@ -7073,6 +7155,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 42,
+			"evoMove": "freezedry",
 			"evolvesTo": null
 		},
 		"baseExp": 168,
@@ -7112,6 +7195,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 32,
+			"evoMove": "swagger",
 			"evolvesTo": "walrein"
 		},
 		"baseExp": 144,
@@ -7132,6 +7216,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 44,
+			"evoMove": "icefang",
 			"evolvesTo": null
 		},
 		"baseExp": 239,
@@ -7268,6 +7353,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "protect",
 			"evolvesTo": "salamence"
 		},
 		"baseExp": 147,
@@ -7288,6 +7374,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 50,
+			"evoMove": "fly",
 			"evolvesTo": null
 		},
 		"baseExp": 270,
@@ -7327,6 +7414,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 20,
+			"evoMove": "confusion|metalclaw",
 			"evolvesTo": "metagross"
 		},
 		"baseExp": 147,
@@ -7347,6 +7435,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 45,
+			"evoMove": "hammerarm",
 			"evolvesTo": null
 		},
 		"baseExp": 270,
@@ -7596,6 +7685,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 32,
+			"evoMove": "earthquake",
 			"evolvesTo": null
 		},
 		"baseExp": 236,
@@ -7635,6 +7725,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 14,
+			"evoMove": "machpunch",
 			"evolvesTo": "infernape"
 		},
 		"baseExp": 142,
@@ -7655,6 +7746,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "closecombat",
 			"evolvesTo": null
 		},
 		"baseExp": 240,
@@ -7694,6 +7786,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 16,
+			"evoMove": "metalclaw",
 			"evolvesTo": "empoleon"
 		},
 		"baseExp": 142,
@@ -7714,6 +7807,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "aquajet",
 			"evolvesTo": null
 		},
 		"baseExp": 239,
@@ -7773,6 +7867,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 34,
+			"evoMove": "closecombat",
 			"evolvesTo": null
 		},
 		"baseExp": 218,
@@ -7812,6 +7907,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 15,
+			"evoMove": "watergun",
 			"evolvesTo": null
 		},
 		"baseExp": 144,
@@ -7851,6 +7947,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 10,
+			"evoMove": "furycutter",
 			"evolvesTo": null
 		},
 		"baseExp": 134,
@@ -7988,6 +8085,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "endeavor",
 			"evolvesTo": null
 		},
 		"baseExp": 173,
@@ -8027,6 +8125,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "block",
 			"evolvesTo": null
 		},
 		"baseExp": 173,
@@ -8067,6 +8166,7 @@
 			"trigger": "level",
 			"level": 20,
 			"gender": "f",
+			"evoMove": "quiverdance",
 			"evolvesTo": null
 		},
 		"baseExp": 148,
@@ -8088,6 +8188,7 @@
 			"trigger": "level",
 			"level": 20,
 			"gender": "m",
+			"evoMove": "quiverdance",
 			"evolvesTo": null
 		},
 		"baseExp": 148,
@@ -8128,6 +8229,7 @@
 			"trigger": "level",
 			"level": 21,
 			"gender": "f",
+			"evoMove": "slash",
 			"evolvesTo": null
 		},
 		"baseExp": 166,
@@ -8225,6 +8327,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 25,
+			"evoMove": "petaldance",
 			"evolvesTo": null
 		},
 		"baseExp": 158,
@@ -8362,6 +8465,7 @@
 		"evolution": {
 			"trigger": "level",
 			"happiness": 255,
+			"evoMove": "return",
 			"evolvesTo": null
 		},
 		"baseExp": 168,
@@ -8441,6 +8545,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 38,
+			"evoMove": "swagger",
 			"evolvesTo": null
 		},
 		"baseExp": 158,
@@ -8499,6 +8604,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 34,
+			"evoMove": "flamethrower",
 			"evolvesTo": null
 		},
 		"baseExp": 168,
@@ -8538,6 +8644,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 33,
+			"evoMove": "block",
 			"evolvesTo": null
 		},
 		"baseExp": 175,
@@ -8672,6 +8779,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 24,
+			"evoMove": "dualchop",
 			"evolvesTo": "garchomp"
 		},
 		"baseExp": 144,
@@ -8692,6 +8800,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 48,
+			"evoMove": "crunch",
 			"evolvesTo": null
 		},
 		"baseExp": 270,
@@ -8751,6 +8860,7 @@
 			"trigger": "level",
 			"happiness": 255,
 			"time": "day",
+			"evoMove": "aurasphere",
 			"evolvesTo": null
 		},
 		"baseExp": 184,
@@ -9025,6 +9135,7 @@
 		"evolution": {
 			"trigger": "level",
 			"location": "electric",
+			"evoMove": "triattack",
 			"evolvesTo": null
 		},
 		"baseExp": 241,
@@ -9185,6 +9296,7 @@
 		"evolution": {
 			"trigger": "level",
 			"location": "mossy",
+			"evoMove": "razorleaf",
 			"evolvesTo": null
 		},
 		"baseExp": 184,
@@ -9205,6 +9317,7 @@
 		"evolution": {
 			"trigger": "level",
 			"location": "icy",
+			"evoMove": "icywind",
 			"evolvesTo": null
 		},
 		"baseExp": 184,
@@ -9287,6 +9400,7 @@
 			"trigger": "item",
 			"gender": "m",
 			"item": "dawnstone",
+			"evoMove": "slash",
 			"evolvesTo": null
 		},
 		"baseExp": 233,
@@ -9307,6 +9421,7 @@
 		"evolution": {
 			"trigger": "level",
 			"location": "electric",
+			"evoMove": "triattack",
 			"evolvesTo": null
 		},
 		"baseExp": 184,
@@ -9348,6 +9463,7 @@
 			"trigger": "item",
 			"gender": "f",
 			"item": "dawnstone",
+			"evoMove": "omniouswind",
 			"evolvesTo": null
 		},
 		"baseExp": 168,
@@ -9750,6 +9866,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 17,
+			"evoMove": "armthrust",
 			"evolvesTo": "emboar"
 		},
 		"baseExp": 146,
@@ -9829,6 +9946,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "slash",
 			"evolvesTo": null
 		},
 		"baseExp": 238,
@@ -9868,6 +9986,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 20,
+			"evoMove": "confuseray",
 			"evolvesTo": null
 		},
 		"baseExp": 147,
@@ -10278,6 +10397,7 @@
 		"rate": "45",
 		"evolution": {
 			"trigger": "trade",
+			"evoMove": "powergem",
 			"evolvesTo": null
 		},
 		"baseExp": 232,
@@ -10356,6 +10476,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 31,
+			"evoMove": "horndrill",
 			"evolvesTo": null
 		},
 		"baseExp": 178,
@@ -10492,6 +10613,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "acid",
 			"evolvesTo": null
 		},
 		"baseExp": 229,
@@ -10569,6 +10691,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 20,
+			"evoMove": "protect",
 			"evolvesTo": "leavanny"
 		},
 		"baseExp": 133,
@@ -10589,6 +10712,7 @@
 		"evolution": {
 			"trigger": "level",
 			"happiness": 255,
+			"evoMove": "slash",
 			"evolvesTo": null
 		},
 		"baseExp": 225,
@@ -10628,6 +10752,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 22,
+			"evoMove": "irondefense",
 			"evolvesTo": "scolipede"
 		},
 		"baseExp": 126,
@@ -10648,6 +10773,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "batonpass",
 			"evolvesTo": null
 		},
 		"baseExp": 218,
@@ -10843,6 +10969,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 35,
+			"evoMove": "hammerarm",
 			"evolvesTo": null
 		},
 		"baseExp": 168,
@@ -10998,6 +11125,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 34,
+			"evoMove": "scaryface",
 			"evolvesTo": null
 		},
 		"baseExp": 169,
@@ -11154,6 +11282,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "nightslash",
 			"evolvesTo": null
 		},
 		"baseExp": 179,
@@ -11311,6 +11440,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 41,
+			"evoMove": "dizzypunch",
 			"evolvesTo": null
 		},
 		"baseExp": 221,
@@ -11448,6 +11578,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 34,
+			"evoMove": "hornleech",
 			"evolvesTo": null
 		},
 		"baseExp": 166,
@@ -11642,6 +11773,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "stickyweb",
 			"evolvesTo": null
 		},
 		"baseExp": 165,
@@ -11681,6 +11813,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 40,
+			"evoMove": "powerwhip",
 			"evolvesTo": null
 		},
 		"baseExp": 171,
@@ -11740,6 +11873,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 49,
+			"evoMove": "magneticflux",
 			"evolvesTo": null
 		},
 		"baseExp": 234,
@@ -11779,6 +11913,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 39,
+			"evoMove": "crunch",
 			"evolvesTo": "eelektross"
 		},
 		"baseExp": 142,
@@ -11995,6 +12130,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 37,
+			"evoMove": "iciclecrash",
 			"evolvesTo": null
 		},
 		"baseExp": 177,
@@ -12169,6 +12305,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 43,
+			"evoMove": "heavyslam",
 			"evolvesTo": null
 		},
 		"baseExp": 169,
@@ -12266,6 +12403,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 54,
+			"evoMove": "superpower",
 			"evolvesTo": null
 		},
 		"baseExp": 179,
@@ -12305,6 +12443,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 54,
+			"evoMove": "bonerush",
 			"evolvesTo": null
 		},
 		"baseExp": 179,
@@ -12441,6 +12580,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 59,
+			"evoMove": "quiverdance",
 			"evolvesTo": null
 		},
 		"baseExp": 248,
@@ -12708,6 +12848,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 16,
+			"evoMove": "needlearm",
 			"evolvesTo": "chesnaught"
 		},
 		"baseExp": 142,
@@ -12728,6 +12869,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "spikyshield",
 			"evolvesTo": null
 		},
 		"baseExp": 239,
@@ -12787,6 +12929,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "mysticalfire",
 			"evolvesTo": null
 		},
 		"baseExp": 240,
@@ -12846,6 +12989,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 36,
+			"evoMove": "watershuriken",
 			"evolvesTo": null
 		},
 		"baseExp": 239,
@@ -12924,6 +13068,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 17,
+			"evoMove": "ember",
 			"evolvesTo": "talonflame"
 		},
 		"baseExp": 134,
@@ -12983,6 +13128,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 9,
+			"evoMove": "protect",
 			"evolvesTo": "vivillon"
 		},
 		"baseExp": 75,
@@ -13003,6 +13149,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 12,
+			"evoMove": "gust",
 			"evolvesTo": null
 		},
 		"baseExp": 185,
@@ -13140,6 +13287,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 32,
+			"evoMove": "aerialace",
 			"evolvesTo": null
 		},
 		"baseExp": 186,
@@ -13179,6 +13327,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 32,
+			"evoMove": "bulletpunch",
 			"evolvesTo": null
 		},
 		"baseExp": 173,
@@ -13491,6 +13640,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 48,
+			"evoMove": "twister",
 			"evolvesTo": null
 		},
 		"baseExp": 173,
@@ -13530,6 +13680,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 37,
+			"evoMove": "aurasphere",
 			"evolvesTo": null
 		},
 		"baseExp": 100,
@@ -13608,6 +13759,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 39,
+			"evoMove": "rockslide",
 			"time": "day",
 			"evolvesTo": null
 		},
@@ -13648,6 +13800,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 39,
+			"evoMove": "freezedry",
 			"time": "night",
 			"evolvesTo": null
 		},
@@ -13669,6 +13822,7 @@
 		"evolution": {
 			"trigger": "level",
 			"moveType": "fairy",
+			"evoMove": "fairywind",
 			"evolvesTo": null
 		},
 		"baseExp": 184,
@@ -13785,6 +13939,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 50,
+			"evoMove": "aquatail",
 			"evolvesTo": null
 		},
 		"baseExp": 270,
@@ -13842,6 +13997,7 @@
 		"rate": "60",
 		"evolution": {
 			"trigger": "trade",
+			"evoMove": "shadowclaw",
 			"evolvesTo": null
 		},
 		"baseExp": 166,
@@ -13919,6 +14075,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 37,
+			"evoMove": "bodyslam",
 			"evolvesTo": null
 		},
 		"baseExp": 180,
@@ -14131,6 +14288,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 34,
+			"evoMove": "spiritshackle",
 			"evolvesTo": null
 		},
 		"baseExp": 239,
@@ -14190,6 +14348,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 34,
+			"evoMove": "darkestlariat",
 			"evolvesTo": null
 		},
 		"baseExp": 239,
@@ -14249,6 +14408,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 34,
+			"evoMove": "sparklingaria",
 			"evolvesTo": null
 		},
 		"baseExp": 239,
@@ -14308,6 +14468,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 28,
+			"evoMove": "beakblast",
 			"evolvesTo": null
 		},
 		"baseExp": 218,
@@ -14387,6 +14548,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 20,
+			"evoMove": "charge",
 			"evolvesTo": "vikavolt"
 		},
 		"baseExp": 140,
@@ -14407,6 +14569,7 @@
 		"evolution": {
 			"trigger": "level",
 			"location": "electric",
+			"evoMove": "thunderbolt",
 			"evolvesTo": null
 		},
 		"baseExp": 225,
@@ -14446,6 +14609,7 @@
 		"evolution": {
 			"trigger": "level",
 			"location": "snow",
+			"evoMove": "icepunch",
 			"evolvesTo": null
 		},
 		"baseExp": 167,
@@ -14504,6 +14668,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 25, 
+			"evoMove": "pollenpuff",
 			"evolvesTo": null
 		},
 		"baseExp": 162,
@@ -14544,6 +14709,7 @@
 			"trigger": "level",
 			"level": 25,
 			"time": "day",
+			"evoMove": "accelerock",
 			"evolvesTo": null
 		},
 		"baseExp": 170,
@@ -14602,6 +14768,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 38,
+			"evoMove": "banefulbunker",
 			"evolvesTo": null
 		},
 		"baseExp": 173,
@@ -14720,6 +14887,7 @@
 			"trigger": "level",
 			"level": 34,
 			"time": "day",
+			"evoMove": "petalblizzard",
 			"evolvesTo": null
 		},
 		"baseExp": 168,
@@ -14799,6 +14967,7 @@
 			"trigger": "level",
 			"level": 33,
 			"gender": "f",
+			"evoMove": "captivate",
 			"evolvesTo": null
 		},
 		"baseExp": 168,
@@ -14838,6 +15007,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 27,
+			"evoMove": "bind",
 			"evolvesTo": null
 		},
 		"baseExp": 175,
@@ -14877,6 +15047,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 18,
+			"evoMove": "doubleslap",
 			"evolvesTo": "tsareena"
 		},
 		"baseExp": 102,
@@ -14896,7 +15067,8 @@
 		"rate": "45",
 		"evolution": {
 			"trigger": "level",
-			"move": "stomp", 
+			"move": "stomp",
+			"evoMove": "tropkick",
 			"evolvesTo": null
 		},
 		"baseExp": 230,
@@ -14993,6 +15165,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 30,
+			"evoMove": "firstimpression",
 			"evolvesTo": null
 		},
 		"baseExp": 186,
@@ -15090,6 +15263,7 @@
 		"evolution": {
 			"trigger": "level",
 			"happiness": 255,
+			"evoMove": "multiattack",
 			"evolvesTo": null
 		},
 		"baseExp": 114,
@@ -15281,6 +15455,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 35,
+			"evoMove": "skyuppercut",
 			"evolvesTo": "kommoo"
 		},
 		"baseExp": 147,
@@ -15301,6 +15476,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 45,
+			"evoMove": "clangingscales",
 			"evolvesTo": null
 		},
 		"baseExp": 270,
@@ -15416,6 +15592,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 43,
+			"evoMove": "cosmicpower",
 			"evolvesTo": "solgaleo|lunala"
 		},
 		"baseExp": 80,
@@ -15436,6 +15613,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 53,
+			"evoMove": "sunsteelstrike",
 			"evolvesTo": null
 		},
 		"baseExp": 136,
@@ -15456,6 +15634,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 53,
+			"evoMove": "moongeistbeam",
 			"evolvesTo": null
 		},
 		"baseExp": 136,
@@ -15703,6 +15882,7 @@
 		"evolution": {
 			"trigger": "level",
 			"level": 20,
+			"evoMove": "scaryface",
 			"time": "night",
 			"evolvesTo": null
 		}
@@ -15821,6 +16001,7 @@
 		"evolution": {
 			"trigger": "item",
 			"item": "icestone",
+			"evoMove": "iciclecrash",
 			"evolvesTo": null
 		}
 	},
@@ -15838,6 +16019,7 @@
 		"evolution": {
 			"trigger": "item",
 			"item": "icestone",
+			"evoMove": "dazzlinggleam",
 			"evolvesTo": null
 		},
 		"baseExp": 177,
@@ -15884,6 +16066,7 @@
 		"inherit": "persian",
 		"evolution": {
 		    "trigger": "level",
+			"evoMove": "swift",
 		    "happiness": 255
 		}
 	},
@@ -16937,6 +17120,7 @@
 		    "trigger": "level",
 		    "level": 25,
 		    "time": "night",
+			"evoMove": "counter",
 		    "evolvesTo": null
 		}
 	},

--- a/config/SGGame/pokemon.json
+++ b/config/SGGame/pokemon.json
@@ -15985,7 +15985,13 @@
 	},
 	"raichualola": {
 		"id": "raichualola",
-		"inherit": "raichu"
+		"inherit": "raichu",
+		"evolution": {
+			"trigger": "item",
+			"item": "thunderstone",
+			"evoMove": "psychic",
+			"evolvesTo": null
+		},
 	},
 	"sandshrewalola": {
 		"id": "sandshrewalola",
@@ -16120,7 +16126,13 @@
 	},
 	"exeggutoralola": {
 		"id": "exeggutoralola",
-		"inherit": "exeggutor"
+		"inherit": "exeggutor",
+		"evolution": {
+			"trigger": "item",
+			"item": "leafstone",
+			"evoMove": "dragonhammer",
+			"evolvesTo": null
+		},
 	},
 	"marowakalola": {
 		"id": "marowakalola",


### PR DESCRIPTION
Missing:
- Raichu-Alola (Psychic)
- Exeggutor-Alola (Dragon Hammer)
- Lycanrosh-Dusk (Thrash)
- New USUM Pokémon
@HoeenCoder