### PR TITLE
Change wavelength plugins to use roomlog (post main-update)

### DIFF
--- a/wavelength-plugins/roomrequest.js
+++ b/wavelength-plugins/roomrequest.js
@@ -128,7 +128,7 @@ exports.commands = {
 			}
 			if (req.type === 'public') {
 				r.add(`This chatroom is slated to go public in 1 week if Upper Staff feel its active enough during this trial phase. ${target[1]}, you are responsible for contacting Upper Staff to make your room public in 1 week.`).update();
-				r.sendModCommand(`(CHATROOM TYPE: Pre-Public. This room can be made public 1 week from this modnote.)`);
+				r.sendMods(`(CHATROOM TYPE: Pre-Public. This room can be made public 1 week from this modnote.)`);
 				r.roomlog(`(CHATROOM TYPE: Pre-Public. This room can be made public 1 week from this modnote.)`);
 				r.modlog(`(CHATROOM TYPE: Pre-Public. This room can be made public 1 week from this modnote.)`);
 			}

--- a/wavelength-plugins/roomrequest.js
+++ b/wavelength-plugins/roomrequest.js
@@ -129,7 +129,7 @@ exports.commands = {
 			if (req.type === 'public') {
 				r.add(`This chatroom is slated to go public in 1 week if Upper Staff feel its active enough during this trial phase. ${target[1]}, you are responsible for contacting Upper Staff to make your room public in 1 week.`).update();
 				r.sendModCommand(`(CHATROOM TYPE: Pre-Public. This room can be made public 1 week from this modnote.)`);
-				r.logEntry(`(CHATROOM TYPE: Pre-Public. This room can be made public 1 week from this modnote.)`);
+				r.roomlog(`(CHATROOM TYPE: Pre-Public. This room can be made public 1 week from this modnote.)`);
 				r.modlog(`(CHATROOM TYPE: Pre-Public. This room can be made public 1 week from this modnote.)`);
 			}
 			r.founder = toId(target[1]);

--- a/wavelength-plugins/survey.js
+++ b/wavelength-plugins/survey.js
@@ -294,7 +294,7 @@ exports.commands = {
 				room.survey.display();
 			}
 
-			this.logEntry(`${user.name} used ${message}.`);
+			this.roomlog(`${user.name} used ${message}.`);
 			return this.privateModCommand(`(A survey was started by ${user.name}.)`);
 		},
 		newhelp: ["/survey create [question] - Create a survey. Requires % @ # & ~"],


### PR DESCRIPTION
Changed the `logEntry` components in the survey and room requests plugins to use `roomlog` as well as `sendModCommand` to `sendMods`