### PR TITLE
IceDevimon Tweak

### DIFF
--- a/mods/digimon/random-teams.js
+++ b/mods/digimon/random-teams.js
@@ -452,7 +452,7 @@ class RandomDigimonTeams extends RandomTeams {
 			"IceDevimon": {
 				species: "IceDevimon",
 				ability: "Virus",
-				moves: ['darkspirit', 'blackout', 'evilfantasy', 'chaoscloud', 'shadowfall', 'evilsquall', 'winterblast', 'gigafreeze'],
+				moves: ['waterblitz', 'blackout', 'evilfantasy', 'icestatue', 'shadowfall', 'evilsquall', 'winterblast', 'gigafreeze'],
 				baseSignatureMove: "frozenclaw",
 				signatureMove: "Frozen Claw",
 			},


### PR DESCRIPTION
Dark Spirit and Chaos cloud on IceDevimon have been changed to Waterblitz and Icestatue.

Reason: Too many evil moves now its 4 like the rest.