### PR TITLE
Buster Drive Animation Fix (Patch ASAP)

### DIFF
--- a/mods/digimon/moves.js
+++ b/mods/digimon/moves.js
@@ -4793,7 +4793,7 @@ let BattleMovedex = {
 			this.add('-prepare', attacker, move.name, defender);
 			this.add('-message', attacker.name + ' is charging up for an attack!');
 			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
-				this.add('-anim', attacker, move.name, defender);
+				this.add('-anim', attacker, "takedown", defender);
 				attacker.removeVolatile(move.id);
 				return;
 			}


### PR DESCRIPTION
Here is the coding fix for Buster Drive in Digimon Showdown, it causes animation error without fix. It needs to be approved as soon as possible for April fools day.